### PR TITLE
Parameter to define a different folder name to consul B

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "consul-kv-compare",
-  "version": "1.0.0",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/consul-kv-compare.ts
+++ b/src/consul-kv-compare.ts
@@ -10,8 +10,8 @@ export class ConsulKvCompare {
   consulB!: string;
   consulBName!: string;
   consulBKeys!: string[];
-  folderName!: string;
-  destinationFolderName!: string;
+  folderNameA!: string;
+  folderNameB!: string;
   folders!: string[];
 
   constructor(cmdOptions: CommanderStatic) {
@@ -31,22 +31,22 @@ export class ConsulKvCompare {
         console.log(`Reading ${this.consulAName} folders...`);
         this.folders = await this.getFolders(this.consulA);
         if(this.folders && this.folders.length > 0) {
-          if (!this.folderName) {
+          if (!this.folderNameA) {
             const folderAnswer: any = await inquirer.prompt({
               name: 'folder',
               type: 'list',
               choices: this.folders,
               message: 'Select Consul folder:',
             });
-            this.folderName = folderAnswer.folder;
+            this.folderNameA = folderAnswer.folder;
           }
-          if (!this.destinationFolderName) {
-            this.destinationFolderName = this.folderName;
+          if (!this.folderNameB) {
+            this.folderNameB = this.folderNameA;
           }
-          this.consulAName = `Consul A [${this.consulA}/${this.folderName}]`;
-          this.consulBName = `Consul B [${this.consulB}/${this.destinationFolderName}]`;
+          this.consulAName = `Consul A [${this.consulA}/${this.folderNameA}]`;
+          this.consulBName = `Consul B [${this.consulB}/${this.folderNameB}]`;
           console.log(`Reading ${this.consulAName} keys...`);
-          this.consulAKeys = await this.getKeys(this.consulA, this.folderName);
+          this.consulAKeys = await this.getKeys(this.consulA, this.folderNameA);
           console.log(`Found ${this.consulAKeys.length} keys on ${this.consulAName}`);
           const confirmBAnswer = await inquirer.prompt({
             type: 'confirm',
@@ -55,7 +55,7 @@ export class ConsulKvCompare {
             message: `Now, connect to ${this.consulBName} network. Continue?`,
           });
           if (confirmBAnswer.confirm) {
-            this.consulBKeys = await this.getKeys(this.consulB, this.destinationFolderName);
+            this.consulBKeys = await this.getKeys(this.consulB, this.folderNameB);
             console.log(`Found ${this.consulBKeys.length} keys on ${this.consulBName}`);
             const diffA = this.consulAKeys.filter(x => !this.consulBKeys.includes(x));
             const diffB = this.consulBKeys.filter(x => !this.consulAKeys.includes(x));
@@ -80,7 +80,7 @@ export class ConsulKvCompare {
                   message: questionMsg,
                 });
                 if (confirmSyncAnswer.confirmSync) {
-                  await this.saveKeys(this.consulB, this.destinationFolderName, diffA);
+                  await this.saveKeys(this.consulB, this.folderNameB, diffA);
                   console.log(`Keys successfully added on ${this.consulBName}.`);
                 }
               }
@@ -104,8 +104,8 @@ export class ConsulKvCompare {
   async collectInputs() {
     this.consulA = this.cmdOptions.consulA;
     this.consulB = this.cmdOptions.consulB;
-    this.folderName = this.cmdOptions.folderName;
-    this.destinationFolderName = this.cmdOptions.destinationFolderName ||
+    this.folderNameA = this.cmdOptions.folderName;
+    this.folderNameB = this.cmdOptions.destinationFolderName ||
       this.cmdOptions.folderName;
 
     // Consul A

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,8 @@ commander
   .version('1.0.0', '-v, --version')
   .option('-a, --consulA <url>', 'URL Consul Server A')
   .option('-b, --consulB <url>', 'URL Consul Server B')
-  .option('-f, --folderName <folderName>', 'Consul Folder Name')
-  .option('-d, --folderNameB <destinationFolderName>', 'Consul B Folder Name')
+  .option('--folderNameA', 'Consul A Folder Name')
+  .option('--folderNameB', 'Consul B Folder Name. Default: folderNameA value')
   .parse(process.argv);
 const consulKvCompare = new ConsulKvCompare(commander);
 consulKvCompare.start();

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ commander
   .option('-a, --consulA <url>', 'URL Consul Server A')
   .option('-b, --consulB <url>', 'URL Consul Server B')
   .option('-f, --folderName <folderName>', 'Consul Folder Name')
+  .option('-d, --folderNameB <destinationFolderName>', 'Consul B Folder Name')
   .parse(process.argv);
 const consulKvCompare = new ConsulKvCompare(commander);
 consulKvCompare.start();


### PR DESCRIPTION
With this option, you can use your cli to copy keys from one consul folder to another. This is useful when you need to create a new project that uses the same configuration keys